### PR TITLE
Scope timer

### DIFF
--- a/wavesexchange_log/Cargo.toml
+++ b/wavesexchange_log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wavesexchange_log"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Dmitry Shuranov <dvshur@gmail.com>"]
 edition = "2018"
 

--- a/wavesexchange_warp/Cargo.toml
+++ b/wavesexchange_warp/Cargo.toml
@@ -13,4 +13,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.8"
 warp = "0.3"
-wavesexchange_log = { path = "../wavesexchange_log", version = "0.4" }
+wavesexchange_log = { path = "../wavesexchange_log", version = "0.5" }


### PR DESCRIPTION
The usage is like this:
```
fn heavy_computations() {
    timer!("Computing The Answer For The Universe And Everything", level = debug);
    // . . . . .
}
```
which will log something like this
```
Sep 24 06:29:04.565 DEBG BEGIN Computing The Answer For The Universe And Everything
Sep 24 06:29:04.566 DEBG END   Computing The Answer For The Universe And Everything: elapsed 0.42ms
```